### PR TITLE
Switch incident times to 12‑hour display

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,4 +21,5 @@ FireWatch. If the endpoint changes, update the `FIREWATCH_URL` constant
 in the script accordingly.
 
 Times shown in the web interface are converted to the US/Eastern timezone
-for consistency with Rockland County's local time.
+and displayed in a 12‑hour format with AM/PM for consistency with
+Rockland County's local time.

--- a/app.py
+++ b/app.py
@@ -18,7 +18,8 @@ def to_est(timestr: str) -> str:
         dt = parser.parse(timestr)
         if dt.tzinfo is None:
             dt = dt.replace(tzinfo=EST)
-        return dt.astimezone(EST).strftime('%Y-%m-%d %H:%M:%S %Z')
+        # Display times in 12 hour format with AM/PM for easier reading
+        return dt.astimezone(EST).strftime('%Y-%m-%d %I:%M:%S %p %Z')
     except Exception as exc:
         print(f"Error parsing '{timestr}': {exc}")
         return timestr


### PR DESCRIPTION
## Summary
- show incident timestamps in 12 hour AM/PM format
- document the new format in README

## Testing
- `python -m py_compile app.py`
- `python - <<'PY'
from app import to_est
print(to_est('2023-10-18 17:30:00'))
PY`

------
https://chatgpt.com/codex/tasks/task_e_68669bc04ab48330abf78f6030bd1bf4