### PR TITLE
Add pagination and Bootstrap styling

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ python app.py
 
 Then open `http://localhost:5000` in your browser.
 
+The index page now uses Bootstrap styling and paginates results 10 per page so large incident lists remain easy to navigate. New incidents appear first after each fetch.
+
 `app.py` now fetches incidents from the JSON feed used by Rockland
 FireWatch. If the endpoint changes, update the `FIREWATCH_URL` constant
 in the script accordingly.

--- a/templates/index.html
+++ b/templates/index.html
@@ -2,21 +2,24 @@
 <html>
 <head>
     <title>Incident Collector</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
 </head>
-<body>
-    <h1>Rockland FireWatch Incidents</h1>
-    <form action="{{ url_for('fetch_route') }}" method="post">
-        <button type="submit">Fetch Incidents Now</button>
+<body class="bg-light">
+    <div class="container py-4">
+    <h1 class="mb-4">Rockland FireWatch Incidents</h1>
+    <form action="{{ url_for('fetch_route') }}" method="post" class="mb-3">
+        <button class="btn btn-primary" type="submit">Fetch Incidents Now</button>
     </form>
 
     {% if csv_exists %}
-    <form action="{{ url_for('download_csv') }}" method="get" style="margin-top:10px;">
-        <button type="submit">Export CSV</button>
+    <form action="{{ url_for('download_csv') }}" method="get" class="mb-4">
+        <button class="btn btn-secondary" type="submit">Export CSV</button>
     </form>
 
     {% if incidents %}
-    <table border="1" cellpadding="5" cellspacing="0">
-        <thead>
+    <div class="table-responsive">
+    <table class="table table-striped">
+        <thead class="table-dark">
             <tr>
                 <th>Time Reported</th>
                 <th>Address</th>
@@ -39,9 +42,24 @@
             {% endfor %}
         </tbody>
     </table>
+    </div>
+    <nav>
+        <ul class="pagination">
+            <li class="page-item {% if page <= 1 %}disabled{% endif %}">
+                <a class="page-link" href="{{ url_for('index', page=page-1) }}">Previous</a>
+            </li>
+            <li class="page-item disabled">
+                <a class="page-link">Page {{ page }} of {{ total_pages }}</a>
+            </li>
+            <li class="page-item {% if page >= total_pages %}disabled{% endif %}">
+                <a class="page-link" href="{{ url_for('index', page=page+1) }}">Next</a>
+            </li>
+        </ul>
+    </nav>
     {% endif %}
     {% else %}
     <p>No data available yet.</p>
     {% endif %}
+</div>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- sort incidents by time reported when saving
- paginate incidents on the home page (10 per page)
- add Bootstrap styling and navigation controls
- document the new features in README

## Testing
- `python -m py_compile app.py`
- `python app.py` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_686ec2e8b380833094081d6776e784da