### PR TITLE
Make app ready for Render deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,11 @@ pip install -r requirements.txt
 python app.py
 ```
 
-Then open `http://localhost:5000` in your browser.
+By default the app listens on port 5000. Deployment platforms like Render set a
+`PORT` environment variable which the application will honor, so no code changes
+are required to run in those environments.
+
+Then open `http://localhost:5000` in your browser when running locally.
 
 The index page now uses Bootstrap styling and paginates results 10 per page so large incident lists remain easy to navigate. New incidents appear first after each fetch.
 

--- a/app.py
+++ b/app.py
@@ -147,4 +147,9 @@ def download_csv():
     return redirect(url_for('index'))
 
 if __name__ == '__main__':
-    app.run(debug=True)
+    # Render sets the PORT environment variable to tell the application which
+    # port to listen on. Default to 5000 for local development.
+    port = int(os.environ.get("PORT", 5000))
+    debug = os.environ.get("DEBUG", "false").lower() == "true"
+    # Listen on all interfaces so Render can route traffic to the container.
+    app.run(host="0.0.0.0", port=port, debug=debug)


### PR DESCRIPTION
## Summary
- add support for Render-provided PORT environment variable
- mention PORT usage in README

## Testing
- `python -m py_compile app.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686ed5532b9c833080fbe1871c198f32