### PR TITLE
Use local JSON data and add helper scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,21 @@ pip install -r requirements.txt
 python app.py
 ```
 
+### Updating data
+
+Run `fetch_incidents.py` to pull the latest incidents and update the CSV/JSON
+files:
+
+```bash
+python fetch_incidents.py
+```
+
+You can also convert an existing CSV to JSON directly:
+
+```bash
+python csv_to_json.py
+```
+
 By default the app listens on port 5000. Deployment platforms like Render set a
 `PORT` environment variable which the application will honor, so no code changes
 are required to run in those environments.

--- a/csv_to_json.py
+++ b/csv_to_json.py
@@ -1,0 +1,18 @@
+import os
+import pandas as pd
+
+CSV_FILE = "rockland_incidents.csv"
+JSON_FILE = "incidents.json"
+
+
+def main():
+    if not os.path.exists(CSV_FILE):
+        print(f"{CSV_FILE} not found")
+        return
+    df = pd.read_csv(CSV_FILE)
+    df.to_json(JSON_FILE, orient="records", indent=2)
+    print(f"Wrote {len(df)} records to {JSON_FILE}")
+
+
+if __name__ == "__main__":
+    main()

--- a/fetch_incidents.py
+++ b/fetch_incidents.py
@@ -1,0 +1,12 @@
+from app import fetch_firewatch, deduplicate_and_save, csv_to_json
+
+
+def main():
+    incidents = fetch_firewatch()
+    if incidents:
+        deduplicate_and_save(incidents)
+        csv_to_json()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- support a local `incidents.json` file in the Flask app
- convert the CSV to JSON after every fetch
- add `fetch_incidents.py` and `csv_to_json.py` scripts
- document the new workflow in the README

## Testing
- `python -m py_compile app.py fetch_incidents.py csv_to_json.py`
- `pip install -r requirements.txt`
- `python fetch_incidents.py` *(fails: Tunnel connection failed 403 Forbidden)*
- `python csv_to_json.py` *(fails: rockland_incidents.csv not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ff504d1448330a555a3915ee59933