### PR TITLE
Remove pagination and display local JSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Incident Scraper
 
-Simple Flask application to fetch and store Rockland County FireWatch incidents.
+Simple Flask application to display incidents stored in `incidents.json`. A
+separate script handles fetching data from the Rockland County FireWatch feed
+and updating the CSV/JSON files.
 
 ## Setup
 
@@ -35,11 +37,9 @@ are required to run in those environments.
 
 Then open `http://localhost:5000` in your browser when running locally.
 
-The index page now uses Bootstrap styling and paginates results 10 per page so large incident lists remain easy to navigate. New incidents appear first after each fetch.
-
-`app.py` now fetches incidents from the JSON feed used by Rockland
-FireWatch. If the endpoint changes, update the `FIREWATCH_URL` constant
-in the script accordingly.
+The index page uses Bootstrap for styling and displays all incidents in a single
+table. New incidents appear first once the JSON file has been updated by the
+`fetch_incidents.py` script.
 
 The CSV tracks these fields:
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -7,12 +7,8 @@
 <body class="bg-light">
     <div class="container py-4">
     <h1 class="mb-4">Rockland FireWatch Incidents</h1>
-    <form action="{{ url_for('fetch_route') }}" method="post" class="mb-3">
-        <button class="btn btn-primary" type="submit">Fetch Incidents Now</button>
-    </form>
-
     {% if csv_exists %}
-    <form action="{{ url_for('download_csv') }}" method="get" class="mb-4">
+    <form action="{{ url_for('download_csv') }}" method="get" class="mb-3">
         <button class="btn btn-secondary" type="submit">Export CSV</button>
     </form>
 
@@ -43,19 +39,6 @@
         </tbody>
     </table>
     </div>
-    <nav>
-        <ul class="pagination">
-            <li class="page-item {% if page <= 1 %}disabled{% endif %}">
-                <a class="page-link" href="{{ url_for('index', page=page-1) }}">Previous</a>
-            </li>
-            <li class="page-item disabled">
-                <a class="page-link">Page {{ page }} of {{ total_pages }}</a>
-            </li>
-            <li class="page-item {% if page >= total_pages %}disabled{% endif %}">
-                <a class="page-link" href="{{ url_for('index', page=page+1) }}">Next</a>
-            </li>
-        </ul>
-    </nav>
     {% endif %}
     {% else %}
     <p>No data available yet.</p>


### PR DESCRIPTION
## Summary
- remove the fetch endpoint and button
- show all incidents from `incidents.json` in a single table
- simplify index logic to load the whole JSON
- update documentation for the new workflow

## Testing
- `python -m py_compile app.py fetch_incidents.py csv_to_json.py`

------
https://chatgpt.com/codex/tasks/task_e_68700a6719a8833083937a55bc1880f4