### PR TITLE
Add simple password-protected login

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,11 @@ pip install -r requirements.txt
 python app.py
 ```
 
+### Authentication
+
+Set the `PASSWORD` environment variable to enable login protection. When set,
+the web interface will prompt for this password before allowing access.
+
 ### Updating data
 
 Run `fetch_incidents.py` to pull the latest incidents and update the CSV/JSON

--- a/templates/login.html
+++ b/templates/login.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Login</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+</head>
+<body class="bg-light">
+<div class="container py-4">
+    <h1 class="mb-4">Login</h1>
+    {% if error %}
+    <div class="alert alert-danger">{{ error }}</div>
+    {% endif %}
+    <form method="post">
+        <div class="mb-3">
+            <label for="password" class="form-label">Password</label>
+            <input type="password" class="form-control" id="password" name="password" required>
+        </div>
+        <button type="submit" class="btn btn-primary">Log In</button>
+    </form>
+</div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add simple login page
- read `PASSWORD` and `SECRET_KEY` from environment
- guard index and CSV download behind login
- document authentication setup in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6870265602b083309ca8e49396539b54