### PR TITLE
Add date range filter

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -8,6 +8,19 @@
     <div class="container py-4">
     <h1 class="mb-4">Rockland FireWatch Incidents</h1>
     {% if csv_exists %}
+    <form method="get" class="row g-3 mb-3">
+        <div class="col-auto">
+            <label for="start_date" class="form-label">Start Date</label>
+            <input type="date" class="form-control" id="start_date" name="start_date" value="{{ start_date }}">
+        </div>
+        <div class="col-auto">
+            <label for="end_date" class="form-label">End Date</label>
+            <input type="date" class="form-control" id="end_date" name="end_date" value="{{ end_date }}">
+        </div>
+        <div class="col-auto align-self-end">
+            <button type="submit" class="btn btn-primary">Apply</button>
+        </div>
+    </form>
     <form action="{{ url_for('download_csv') }}" method="get" class="mb-3">
         <button class="btn btn-secondary" type="submit">Export CSV</button>
     </form>


### PR DESCRIPTION
## Summary
- add a date range filter to the index route
- show a calendar widget above the table to pick start and end dates

## Testing
- `python -m py_compile app.py`
- `python app.py` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68702b79e15c833095d2b96378c4aef8