### PR TITLE
Add incident type filter

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -17,6 +17,15 @@
             <label for="end_date" class="form-label">End Date</label>
             <input type="date" class="form-control" id="end_date" name="end_date" value="{{ end_date }}">
         </div>
+        <div class="col-auto">
+            <label for="incident_type" class="form-label">Incident Type</label>
+            <select class="form-select" id="incident_type" name="incident_type">
+                <option value="">All</option>
+                {% for t in incident_types %}
+                <option value="{{ t }}" {% if t == incident_type %}selected{% endif %}>{{ t }}</option>
+                {% endfor %}
+            </select>
+        </div>
         <div class="col-auto align-self-end">
             <button type="submit" class="btn btn-primary">Apply</button>
         </div>


### PR DESCRIPTION
## Summary
- allow filtering incidents by type
- render dropdown of incident types on the index page

## Testing
- `python -m py_compile app.py fetch_incidents.py csv_to_json.py`
- `pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_68710e309df88330a7ce2226fdd78b1d