### PR TITLE
Add multi-select for incident types

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ Then open `http://localhost:5000` in your browser when running locally.
 The index page uses Bootstrap for styling and displays all incidents in a single
 table. New incidents appear first once the JSON file has been updated by the
 `fetch_incidents.py` script.
+You can filter results by date range and select one or more incident types using
+the multi-select dropdown above the table.
 
 The CSV tracks these fields:
 

--- a/app.py
+++ b/app.py
@@ -146,7 +146,8 @@ def index():
     logger.info("Rendering index page")
     start_date_str = request.args.get('start_date', '')
     end_date_str = request.args.get('end_date', '')
-    selected_type = request.args.get('incident_type', '')
+    # Allow selecting multiple incident types via ?incident_type=A&incident_type=B
+    selected_types = [t for t in request.args.getlist('incident_type') if t]
     start_date = None
     end_date = None
     if start_date_str:
@@ -174,8 +175,8 @@ def index():
                 df = df[df['sort_time'].dt.date <= end_date]
 
             incident_types = sorted(df['incident_type'].dropna().unique().tolist())
-            if selected_type:
-                df = df[df['incident_type'] == selected_type]
+            if selected_types:
+                df = df[df['incident_type'].isin(selected_types)]
 
             df.sort_values('sort_time', ascending=False, inplace=True)
             df.drop(columns=['sort_time'], inplace=True)
@@ -189,7 +190,7 @@ def index():
         start_date=start_date_str,
         end_date=end_date_str,
         incident_types=incident_types,
-        incident_type=selected_type,
+        selected_types=selected_types,
     )
 
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -18,11 +18,10 @@
             <input type="date" class="form-control" id="end_date" name="end_date" value="{{ end_date }}">
         </div>
         <div class="col-auto">
-            <label for="incident_type" class="form-label">Incident Type</label>
-            <select class="form-select" id="incident_type" name="incident_type">
-                <option value="">All</option>
+            <label for="incident_type" class="form-label">Incident Types</label>
+            <select class="form-select" id="incident_type" name="incident_type" multiple size="3">
                 {% for t in incident_types %}
-                <option value="{{ t }}" {% if t == incident_type %}selected{% endif %}>{{ t }}</option>
+                <option value="{{ t }}" {% if t in selected_types %}selected{% endif %}>{{ t }}</option>
                 {% endfor %}
             </select>
         </div>


### PR DESCRIPTION
## Summary
- allow picking multiple incident types in the index filter
- support filtering by several types in the backend
- document the new capability in the README

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile app.py fetch_incidents.py csv_to_json.py`


------
https://chatgpt.com/codex/tasks/task_e_68713062e8c0833094bc6f879a92b306